### PR TITLE
Bump reqwest version to 0.9.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["selenium", "testing", "browser", "automation"]
 
 
 [dependencies]
-reqwest = "0.8.7"
+reqwest = "0.9.5"
 url = "1.7.1"
 serde = "1.0.71"
 serde_json = "1.0.26"


### PR DESCRIPTION
This should fix some OpenSSL issues on Linux.